### PR TITLE
Fix clock_getres() calls on FreeBSD

### DIFF
--- a/posixrealtime.c
+++ b/posixrealtime.c
@@ -327,6 +327,7 @@ PHP_FUNCTION(posix_clock_getres)
 PHP_FUNCTION(posix_is_clock_supported)
 {
     long clock_id;
+	struct timespec tp;
 
     if (ZEND_NUM_ARGS() > 1) {
         WRONG_PARAM_COUNT;
@@ -336,10 +337,10 @@ PHP_FUNCTION(posix_is_clock_supported)
         return;
     }
 
-    if (clock_getres(clock_id, NULL) == -1) {
+    if (clock_getres(clock_id, &tp) == -1) {
         if (errno == EINVAL) {
             RETURN_FALSE;
-        }
+		}
     }
 
     RETURN_TRUE;

--- a/tests/007-posix_is_clock_supported_basic.phpt
+++ b/tests/007-posix_is_clock_supported_basic.phpt
@@ -12,7 +12,7 @@ var_dump(posix_is_clock_supported(PSXRT_CLK_REALTIME));
 //	testing it
 var_dump(defined('PSXRT_CLK_MONOTONIC') && !posix_is_clock_supported(PSXRT_CLK_MONOTONIC));
 
-var_dump(posix_is_clock_supported(PHP_INT_MAX));
+var_dump(posix_is_clock_supported(42));
 
 --EXPECTF--
 bool(true)


### PR DESCRIPTION
* If no struct timespec is passed to clock_getres the syscall is a no-op
  returning 0 on FreeBSD (10.x at least) and does not set EINVAL.
* Passing PHP_INT_MAX as clock ID on 64-bit systems turns the clock id
  into a negative value. This then does the same as the two FreeBSD
  specific (undocumented) clocks CLOCK_(THREAD|PROCESS)_CPUTIME_ID [1].
  Fix the test to use a different value that's not likely to overflow.

[1] /* sync with cputick2usec */